### PR TITLE
Bump version and doc update for release

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -9,6 +9,11 @@ See also: [Connecting Anki to the sync server](ConnectingAnki.md)
 ```
 $ pip install djankiserv
 ```
+This will not install a database driver. You may pull in a supported database driver by adding an extra to the `pip` install(`mysql` and `pgsql` are supported):
+```
+$ pip install djankiserv[pgsql]
+```
+Which will also install `psycopg2-binary`. If you choose `mysql`, you will also need to have the `mysql` development headers, so that `pip` can build the driver (tested with `libmariadb-dev` on Ubuntu/Debian).
 
 ```
 INSTALLED_APPS = [

--- a/images/main/Dockerfile
+++ b/images/main/Dockerfile
@@ -1,7 +1,7 @@
 # vim:set ft=dockerfile
 FROM python:3.8-slim
 
-RUN apt update && apt install -y gcc git libmariadb-dev && apt -y autoremove && apt -y clean && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y gcc git && apt -y autoremove && apt -y clean && rm -rf /var/lib/apt/lists/*
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -12,6 +12,6 @@ WORKDIR /app
 COPY ./src /app
 COPY ./scripts /app/scripts
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.pgonly.txt
 
 CMD ["/bin/bash", "/app/scripts/runserver.sh"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,7 +32,7 @@ wrapt = ">=1.11,<2.0"
 
 [[package]]
 name = "certifi"
-version = "2020.11.8"
+version = "2020.12.5"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -434,7 +434,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.2.1"
+version = "20.2.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -458,10 +458,14 @@ category = "dev"
 optional = false
 python-versions = "*"
 
+[extras]
+mysql = ["mysqlclient"]
+pgsql = ["psycopg2-binary"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "f67c23e95abb4622e886fee6e587c08c9a8e332d2fdfa6d553d3b5d62a69b065"
+content-hash = "5b0a0e2a753b8ca09f1923f9cc1f6f122831e618a97b60305a8897a1ebe47c77"
 
 [metadata.files]
 appdirs = [
@@ -477,8 +481,8 @@ astroid = [
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
 certifi = [
-    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
-    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
 ]
 cfgv = [
     {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
@@ -713,8 +717,8 @@ urllib3 = [
     {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},
-    {file = "virtualenv-20.2.1.tar.gz", hash = "sha256:e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5"},
+    {file = "virtualenv-20.2.2-py2.py3-none-any.whl", hash = "sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c"},
+    {file = "virtualenv-20.2.2.tar.gz", hash = "sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "djankiserv"
-version = "0.0.7-rc1"
+version = "0.0.7"
 description = "Django-based synchronisation and API server for Anki"
 authors = ["Anton Melser <anton@melser.org>"]
 maintainers = ["Anton Melser <anton@melser.org>"]

--- a/scripts/buildaddon.sh
+++ b/scripts/buildaddon.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-source scripts/runsetup.sh
-
-cd addon/
-
-zip -r ../djankiserv.ankiaddon *

--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.4; python_full_version >= "3.6.1"
 asgiref==3.3.1; python_version >= "3.6"
 astroid==2.4.2; python_version >= "3.5"
-certifi==2020.11.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+certifi==2020.12.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 cfgv==3.2.0; python_full_version >= "3.6.1"
 chardet==3.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 colorama==0.4.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
@@ -38,5 +38,5 @@ six==1.15.0; python_full_version >= "3.6.1" and python_version >= "3.5"
 sqlparse==0.4.1; python_version >= "3.6"
 toml==0.10.2; python_full_version >= "3.6.1" and python_version < "4" and python_version >= "3.5" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4")
 urllib3==1.26.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-virtualenv==20.2.1; python_full_version >= "3.6.1"
+virtualenv==20.2.2; python_full_version >= "3.6.1"
 wrapt==1.12.1; python_version >= "3.5"


### PR DESCRIPTION
The supported db drivers were moved to extras, so added this info to the
docs

Also:
- Remove an obsolete build script (for the moved addon)
- Update deps
- Update the docker file to build for pgsql and forget the mariadb
dependency